### PR TITLE
If the events HTTPS request stops, restart it

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -126,7 +126,7 @@ function Cache() {
           }
         });
       } else {
-        //Error 
+        //Error
         callback('cacheFile does not exist.');
       }
     });
@@ -134,30 +134,11 @@ function Cache() {
 }
 
 /**
- * @name getEvents
- * @param {Object} opts The options. Consists of public, core, accessToken, and event.
- * @returns {EventEmitter} Emitter
+ * @name listenForSparkEvents
+ * @param {Object} options The options. Consists of public, core, accessToken, and event.
+ * @param {EventEmitter} emitter
  */
-
-//Internal abstraction for events
-exports.getEvents = function getEvents(opts) {
-  var options = defaultOptions(opts.accessToken);
-  if(!opts.pub) {
-    options.path += 'devices/';
-
-    if (opts.coreName) {
-      options.path += opts.coreName + '/';
-    }
-  } 
-
-  options.path += 'events';
-
-  if(opts.eventName) {
-    options.path += '/' + opts.eventName;
-  }
-
-  var emitter = new events.EventEmitter();
-
+function listenForSparkEvents(options, emitter) {
   var req = https.request(options, function(res) {
 
     var lastEventName;
@@ -166,7 +147,7 @@ exports.getEvents = function getEvents(opts) {
       if(data[0].toString() === ':') {return;} //Drop ':ok' message
 
       //Get each line of data in this chunk
-      var lines = data.toString().split(/\n/); 
+      var lines = data.toString().split(/\n/);
 
       //Make a place to put the data
       var eventMap = {};
@@ -200,18 +181,52 @@ exports.getEvents = function getEvents(opts) {
       }
     });
 
+    // if the request is killed, start a new one
+    res.on('end', function() {
+      listenForSparkEvents(options, emitter);
+    });
+
     res.on('error', function (e) {
       emitter.emit('error', e);
     });
   });
 
-  //req.setSocketKeepAlive(true);
+  req.setSocketKeepAlive(true);
 
   req.on('error', function (e) {
     emitter.emit('error', e);
   });
 
   req.end();
+}
+
+/**
+ * @name getEvents
+ * @param {Object} opts The options. Consists of public, core, accessToken, and event.
+ * @returns {EventEmitter} Emitter
+ */
+
+//Internal abstraction for events
+exports.getEvents = function getEvents(opts) {
+  var options = defaultOptions(opts.accessToken);
+  if(!opts.pub) {
+    options.path += 'devices/';
+
+    if (opts.coreName) {
+      options.path += opts.coreName + '/';
+    }
+  }
+
+  options.path += 'events';
+
+  if(opts.eventName) {
+    options.path += '/' + opts.eventName;
+  }
+
+  var emitter = new events.EventEmitter();
+
+  //Start listening for events
+  listenForSparkEvents(options, emitter);
 
   //With great power comes great responsibility.
   return emitter;


### PR DESCRIPTION
I'm using sparknode to listen long-term for an event from my core, which is hooked up to a water sensor.  The event is basically `omg-your-house-is-filling-with-water`, so I want to ensure that my app is listening for the event reliably.

Currently, my app will quit every hour or so.  Tracing the cause, it appears that the spark HTTPS event stream drops the connection after X minutes of inactivity, even with Keep Alive on.  Once the HTTPS stream ends, there are no outstanding events for Node.js to wait for, so my app exits.

This change listens for an `end` event to fire from the `res`ponse.  If we see an `end` event, we simply immediately request a new connection.  To do this, the HTTP setup functionality was moved into a new `listenForSparkEvents()` function.

This change has been tested on my core.  It picks up dropped connections and initiates a new connection successfully.

Note, a few additional lines with trailing spaces were changed as well. 
